### PR TITLE
Fix encoding detection for READ/string

### DIFF
--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -206,7 +206,7 @@ REBINT Mode_Syms[] = {
 	if (args & (AM_READ_STRING | AM_READ_LINES)) {
 		REBSER *nser = Decode_UTF_String(BIN_HEAD(ser), file->actual, -1);
 		if (nser == NULL) {
-			nser = ser;
+			Trap0(RE_BAD_DECODE);
 		}
 		Set_String(ds, nser);
 		if (args & AM_READ_LINES) Set_Block(ds, Split_Lines(ds));


### PR DESCRIPTION
Files with a BOM are no properly handled. Files without a BOM are
again decoded using UTF-8. Trying to READ/string a file with an encoding
for which support is not yet implemented (UCS4 LE and BE) now causes an
error.

This fixes zsx/r3#13, regressions introduced by 8336a45 and 70c7c3a, and
[CureCode issue cc#2186](http://issue.cc/r3/2186).
