### PR TITLE
Fix LAUNCH to properly work with argv-based CALL

### DIFF
--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -16,13 +16,9 @@ launch: func [
 	script [file! string! none!] "The name of the script"
 	/args arg [string! block! none!] "Arguments to the script"
 	/wait "Wait for the process to terminate"
-	/local exe
 ][
 	if file? script [script: to-local-file clean-path script]
-	exe: to-local-file system/options/boot
-
-	; Quote everything, just in case it has spaces:
-	args: to-string reduce [{"} exe {" "} script {" }]
+	args: reduce [to-local-file system/options/boot script]
 	if arg [append args arg]
 	either wait [call/wait args] [call args]
 ]


### PR DESCRIPTION
The more comprehensive implementation of CALL switched to a block-based
interface for passing multiple arguments. This broke LAUNCH, as LAUNCH
would simple concatenate interpreter and script into a single string and
pass that to CALL. This commit adapts LAUNCH to pass a block to CALL.
