### PR TITLE
Restructure platform metadata for easier extensibility

### DIFF
--- a/src/boot/platforms.r
+++ b/src/boot/platforms.r
@@ -14,18 +14,83 @@ REBOL [
 	}
 ]
 
-Amiga		[1 m68k20+ 2 m68k 3 ppc]
-Macintosh	[1 mac-ppc 2 mac-m68k 3 mac-misc 4 osx-ppc 5 osx-x86]
-Windows		[1 win32-x86 2 dec-alpha 3 win32-x64]
-Linux		[1 libc5-x86 2 libc6-2-3-x86 3 libc6-2-5-x86 4 libc6-2-11-x86 10 libc6-ppc 20 libc6-arm 30 libc6-mips 40 libc-x64]
-Haiku		[75 x86-32]
-BSDi		[1 x86]
-FreeBSD		[1 x86 2 elf-x86]
-NetBSD		[1 x86 2 ppc 3 m68k 4 dec-alpha 5 sparc]
-OpenBSD		[1 x86 2 ppc 3 m68k 4 elf-x86 5 sparc]
-Sun			[1 sparc]
-SGI			[]
-HP			[]
-Android		[1 arm]
-free-slot	[]
-WindowsCE	[1 sh3 2 mips 5 arm 6 sh4]
+1 Amiga [
+	1 m68k20+
+	2 m68k
+	3 ppc
+]
+
+2 Macintosh [
+	1 mac-ppc
+	2 mac-m68k
+	3 mac-misc
+	4 osx-ppc
+	5 osx-x86
+]
+
+3 Windows [
+	1 win32-x86
+	2 dec-alpha
+	3 win32-x64
+]
+
+4 Linux [
+	1 libc5-x86
+	2 libc6-2-3-x86
+	3 libc6-2-5-x86
+	4 libc6-2-11-x86
+	10 libc6-ppc
+	20 libc6-arm
+	30 libc6-mips
+	40 libc-x64
+]
+
+5 Haiku [
+	75 x86-32
+]
+
+6 BSDi [
+	1 x86
+]
+
+7 FreeBSD [
+	1 x86
+	2 elf-x86
+]
+
+8 NetBSD [
+	1 x86
+	2 ppc
+	3 m68k
+	4 dec-alpha
+	5 sparc
+]
+
+9 OpenBSD [
+	1 x86
+	2 ppc
+	3 m68k
+	4 elf-x86
+	5 sparc
+]
+
+10 Sun [
+	1 sparc
+]
+
+11 SGI []
+
+12 HP []
+
+13 Android [
+	1 arm
+]
+
+14 free-slot []
+
+15 WindowsCE [
+	1 sh3
+	2 mips
+	5 arm
+	6 sh4
+]

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -791,8 +791,8 @@ change at-value product to lit-word! product
 plats: load %platforms.r
 
 change/only at-value platform reduce [
-	any [pick plats version/4 * 2 - 1 "Unknown"]
-	any [select pick plats version/4 * 2 version/5 ""]
+	any [select plats version/4 "Unknown"]
+	any [select third any [find/skip plats version/4 3 []] version/5 ""]
 ]
 
 ob: context boot-sysobj


### PR DESCRIPTION
Platform modifications will now mostly be additional lines and no longer
changes within the major platform line. This should make
platform-related merges easier, in the future.

This is just a 1:1 translation of the current platforms list into the
new format. No intended changes in platform numbers in this commit.
