### PR TITLE
Forward-port all missing changes from mainline rebol/rebol to Atronix

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -187,12 +187,10 @@ halt: native [
 ]
 
 if: native [
-	{If TRUE condition, return arg; evaluate block args by default}
+	{If TRUE condition, return arg; evaluate blocks by default.}
 	condition
 	true-branch
-	/else "If FALSE condition, return second arg; evaluate block by default"
-	false-branch
-	/only "Suppress evaluation of block args."
+	/only "Return block arg instead of evaluating it."
 ]
 
 loop: native [
@@ -308,10 +306,10 @@ try: native [
 ]
 
 unless: native [
-	{If FALSE condition, return arg; evaluate block args by default.}
+	{If FALSE condition, return arg; evaluate blocks by default.}
 	condition
 	false-branch
-	/only "Suppress evaluation of block args."
+	/only "Return block arg instead of evaluating it."
 ]
 
 until: native [

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -272,7 +272,6 @@ remove-each: native [
 return: native [
 	{Returns a value from a function.}
 	value [any-type!]
-	/redo {Upon return, re-evaluate the returned result. (Used for DO)}
 ]
 
 switch: native [

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -368,16 +368,14 @@ enum {
 
 	if (D_REF(4)) {	//QUIT
 		if (Try_Block_Halt(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
-			// We can be here for 2 reasons:
-			// 1. a QUIT/HALT condition
-			// 2. an error condition
+			// We are here because of a QUIT/HALT condition.
 			ret = DS_NEXT;
 			if (VAL_ERR_NUM(ret) == RE_QUIT)
 				ret = VAL_ERR_VALUE(ret);
 			else if (VAL_ERR_NUM(ret) == RE_HALT)
 				Halt_Code(RE_HALT, 0);
 			else
-				Throw_Error(VAL_ERR_OBJECT(ret));
+				Crash(RP_NO_CATCH);
 			*DS_RETURN = *ret;
 			return R_RET;
 		}

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -686,7 +686,6 @@ got_err:
 {
 	REBVAL *arg = D_ARG(1);
 
-	if (D_REF(2)) VAL_SET_OPT(arg, OPTS_REVAL);
 	SET_THROW(ds, RE_RETURN, arg);
 	return R_RET;
 }

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -618,27 +618,13 @@ got_err:
 /*
 ***********************************************************************/
 {
-	REBVAL *cond = D_ARG(1);
-	REBCNT argnum = 2;
-
-	if (!D_REF(3)) {	// no /else
-		if (IS_FALSE(cond)) return R_NONE;
-	} else
-		if (IS_FALSE(cond)) argnum = 4;
-
-	if (IS_BLOCK(D_ARG(argnum)) && !D_REF(5) /* not using /ONLY */) {
-		DO_BLK(D_ARG(argnum));
+	if (IS_FALSE(D_ARG(1))) return R_NONE;
+	if (IS_BLOCK(D_ARG(2)) && !D_REF(3) /* not using /ONLY */) {
+		DO_BLK(D_ARG(2));
 		return R_TOS1;
-	} {
-		if (argnum == 2)
-			return R_ARG2;
-		else {
-			// No R_ARG4, but IF/ELSE may get the axe (CC #2077)
-			DS_RET_VALUE(D_ARG(argnum));
-			return R_RET;
-		}
+	} else {
+		return R_ARG2;
 	}
-
 }
 
 

--- a/src/core/n-math.c
+++ b/src/core/n-math.c
@@ -247,8 +247,7 @@ enum {SINE, COSINE, TANGENT};
 **
 */	REBNATIVE(shift)
 /*
-**		shift int bits /logical
-**		Clip shift at 64 bits.
+**		shift int bits arithmetic or logical
 **
 ***********************************************************************/
 {

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -158,14 +158,17 @@ static REBCNT *CRC_Table;
 {
 	REBINT m, n;
 	REBINT hash;
+	REBCNT ulen;
 
 	if (len < 0) len = LEN_BYTES(str);
 
 	hash = (REBINT)len + (REBINT)((REBYTE)LO_CASE(*str));
 
-	for (; len > 0; str++, len--) {
+	ulen = (REBCNT)len; // so the & operation later isn't for the wrong type
+
+	for (; ulen > 0; str++, ulen--) {
 		n = *str;
-		if (n > 127 && NZ(m = Decode_UTF8_Char(&str, &len))) n = m; // mods str, len
+		if (n > 127 && NZ(m = Decode_UTF8_Char(&str, &ulen))) n = m; // mods str, ulen
 		if (n < UNICODE_CASES) n = LO_CASE(n);
 		n = (REBYTE)((hash >> CRCSHIFTS) ^ (REBYTE)n); // drop upper 8 bits
 		hash = MASK_CRC(hash << 8) ^ (REBINT)CRC_Table[n];

--- a/src/core/s-find.c
+++ b/src/core/s-find.c
@@ -257,7 +257,7 @@
 **			-3: no match, s2 > s1
 **			-1: no match, s1 > s2
 **			 0: exact match
-**		     1: non-case match, s2 > s1
+**			 1: non-case match, s2 > s1
 **			 3: non-case match, s1 > s2
 **
 **		So, result + 2 for no-match gives proper sort order.
@@ -271,7 +271,7 @@
 	REBCNT l1 = LEN_BYTES(s1);
 	REBINT result = 0;
 
-	for (; l2 > 0; s1++, s2++, l2--) {
+	for (; l1 > 0 && l2 > 0; s1++, s2++, l1--, l2--) {
 		c1 = (REBYTE)*s1;
 		c2 = (REBYTE)*s2;
 		if (c1 > 127) c1 = Decode_UTF8_Char(&s1, &l1); //!!! can return 0 on error!
@@ -284,6 +284,7 @@
 			if (!result) result = (c1 > c2) ? 3 : 1;
 		}
 	}
+	if (l1 != l2) result = (l1 > l2) ? -1 : -3;
 
 	return result;
 }

--- a/src/core/s-unicode.c
+++ b/src/core/s-unicode.c
@@ -768,7 +768,7 @@ ConversionResult ConvertUTF8toUTF32 (
 
 /***********************************************************************
 **
-*/	REBCNT Decode_UTF8_Char(REBYTE **str, REBINT *len)
+*/	REBCNT Decode_UTF8_Char(REBYTE **str, REBCNT *len)
 /*
 **		Converts a single UTF8 code-point (to 32 bit).
 **		Errors are returned as zero. (So prescan source for null.)
@@ -817,7 +817,7 @@ ConversionResult ConvertUTF8toUTF32 (
 
 /***********************************************************************
 **
-*/	int Decode_UTF8(REBUNI *dst, REBYTE *src, REBINT len, REBFLG ccr)
+*/	int Decode_UTF8(REBUNI *dst, REBYTE *src, REBCNT len, REBFLG ccr)
 /*
 **		Decode UTF8 byte string into a 16 bit preallocated array.
 **
@@ -853,7 +853,7 @@ ConversionResult ConvertUTF8toUTF32 (
 
 /***********************************************************************
 **
-*/	int Decode_UTF16(REBUNI *dst, REBYTE *src, REBINT len, REBFLG lee, REBFLG ccr)
+*/	int Decode_UTF16(REBUNI *dst, REBYTE *src, REBCNT len, REBFLG lee, REBFLG ccr)
 /*
 **		dst: the desination array, must always be large enough!
 **		src: source binary data

--- a/src/include/sys-dec-to-char.h
+++ b/src/include/sys-dec-to-char.h
@@ -2,8 +2,9 @@
 **
 **  REBOL [R3] Language Interpreter and Run-time Environment
 **
-**  Copyright 2012 REBOL Technologies
 **  REBOL is a trademark of REBOL Technologies
+**
+**  Copyright 2012 Saphirion AG
 **
 **  Licensed under the Apache License, Version 2.0 (the "License");
 **  you may not use this file except in compliance with the License.

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -42,7 +42,7 @@ function: funct: func [
 	body: copy/deep body
 	; Collect all set-words in the body as words to be used as locals, and add
 	; them to the spec. Don't include the words already in the spec or object.
-	append spec collect-words/deep/set/ignore body either with [
+	insert find/tail spec /local collect-words/deep/set/ignore body either with [
 		; Make our own local object if a premade one is not provided
 		unless object? object [object: make object! object]
 		bind body object  ; Bind any object words found in the body

--- a/src/mezz/mezz-func.r
+++ b/src/mezz/mezz-func.r
@@ -35,7 +35,7 @@ closure: func [
 	body: copy/deep body
 	; Collect all set-words in the body as words to be used as locals, and add
 	; them to the spec. Don't include the words already in the spec or object.
-	append spec collect-words/deep/set/ignore body either with [
+	insert find/tail spec /local collect-words/deep/set/ignore body either with [
 		; Make our own local object if a premade one is not provided
 		unless object? object [object: make object! object]
 		bind body object  ; Bind any object words found in the body

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -422,7 +422,7 @@ say-browser: does [
 	print "Opening web browser..."
 ]
 
-upgrade: funct [
+upgrade: function [
 	"Check for newer versions (update REBOL)."
 ][
 	print "Fetching upgrade check ..."

--- a/src/mezz/prot-tls.r
+++ b/src/mezz/prot-tls.r
@@ -985,7 +985,7 @@ tls-read-data: func [
 	return false
 ]
 
-tls-awake: funct [event [event!]] [
+tls-awake: function [event [event!]] [
 	debug ["TLS Awake-event:" event/type]
 	port: event/port
 	tls-port: port/locals

--- a/src/os/linux/dev-event.c
+++ b/src/os/linux/dev-event.c
@@ -100,8 +100,9 @@ void X_Finish_Resizing();
 **
 */	DEVICE_CMD Query_Events(REBREQ *req)
 /*
-**		Wait for an event or a timeout sepecified by req->length.
-**		This is used by WAIT as the main timing method.
+**		Wait for an event, or a timeout (in milliseconds) specified by
+**		req->length. The latter is used by WAIT as the main timing
+**		method.
 **
 ***********************************************************************/
 {

--- a/src/os/osx/dev-event.c
+++ b/src/os/osx/dev-event.c
@@ -82,8 +82,9 @@ void Done_Device(int handle, int error);
 **
 */	DEVICE_CMD Query_Events(REBREQ *req)
 /*
-**		Wait for an event or a timeout sepecified by req->length.
-**		This is used by WAIT as the main timing method.
+**		Wait for an event, or a timeout (in milliseconds) specified by
+**		req->length. The latter is used by WAIT as the main timing
+**		method.
 **
 ***********************************************************************/
 {

--- a/src/os/porting-templates/dev-event.c
+++ b/src/os/porting-templates/dev-event.c
@@ -82,8 +82,9 @@ void Done_Device(int handle, int error);
 **
 */	DEVICE_CMD Query_Events(REBREQ *req)
 /*
-**		Wait for an event or a timeout specified by req->length.
-**		This is used by WAIT as the main timing method.
+**		Wait for an event, or a timeout (in milliseconds) specified by
+**		req->length. The latter is used by WAIT as the main timing
+**		method.
 **
 ***********************************************************************/
 {


### PR DESCRIPTION
This pull request incorporates all (_except one_) missing changes that were applied to mainline rebol/rebol but up to now missing from Atronix.

The following three pull requests were missing wholesale:
- rebol/rebol#186 (BrianHawley/fix-2109-function-local-not-at-end)
- rebol/rebol#198 (BrianHawley/wish-2121-no-return-redo)
- rebol/rebol#193 (BrianHawley/fix-2113-hash-collision)

Parts of the following six pull requests were missing (mostly just comment changes):
- rebol/rebol#185 (BrianHawley/wish-2077-no-if-else)
- rebol/rebol#167 (earl/fix-851-try-catch-quit)
- rebol/rebol#149 (ladislav/shift)
- rebol/rebol#144 (ladislav/STRTOD)
- rebol/rebol#109 (BrianHawley/wish-1973-function)
- rebol/rebol#168 (earl/fix-posix-wait-rate)

Finally, the one exception, which is _not_ contained in this pull request. The following change was merged but then reverted in Atronix:
- rebol/rebol#183 (BrianHawley/wish-2005-find-all-speedup)

When this pull request is merged, Atronix becomes a strict superset of mainline rebol/rebol. We could then do a no-op merge (with the `ours` strategy) to finally properly tie those two trees together in Git.
